### PR TITLE
resolve path setting problem in macOS

### DIFF
--- a/MISS_HIT.m
+++ b/MISS_HIT.m
@@ -11,6 +11,8 @@ classdef MISS_HIT
             if ismac
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';
+                % add path(substitute your own user name for rookie)
+                setenv('PATH', getenv('PATH')+":/Users/rookie/.local/bin/")
             elseif isunix
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';

--- a/MISS_HIT.m
+++ b/MISS_HIT.m
@@ -12,7 +12,7 @@ classdef MISS_HIT
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';
                 [~,username]=system('id -un');
-                setenv('PATH', getenv('PATH')+":/Users/"+username+"/.local/bin/")
+                setenv('PATH', getenv('PATH')+":/Users/"+username(1:end-1)+"/.local/bin/")
             elseif isunix
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';

--- a/MISS_HIT.m
+++ b/MISS_HIT.m
@@ -11,8 +11,8 @@ classdef MISS_HIT
             if ismac
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';
-                % add path(substitute your own user name for rookie)
-                setenv('PATH', getenv('PATH')+":/Users/rookie/.local/bin/")
+                [~,username]=system('id -un');
+                setenv('PATH', getenv('PATH')+":/Users/"+username+"/.local/bin/")
             elseif isunix
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';
@@ -26,6 +26,7 @@ classdef MISS_HIT
 
             % default options
             default_args = {['--fix ', suppress_output]};
+%             default_args = {['--fix ']};
             default_args(1:nargin) = varargin;
 
             % get active editor content

--- a/MISS_HIT.m
+++ b/MISS_HIT.m
@@ -11,8 +11,8 @@ classdef MISS_HIT
             if ismac
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';
-                [~,username]=system('id -un');
-                setenv('PATH', getenv('PATH')+":/Users/"+username(1:end-1)+"/.local/bin/")
+                [~, username] = system('id -un');
+                setenv('PATH', getenv('PATH') + ":/Users/" + username(1:end - 1) + "/.local/bin/");
             elseif isunix
                 suppress_output = '1> /dev/null 2> /dev/null';
                 set_environment = 'export PYTHONIOENCODING=UTF-8 && ';
@@ -26,7 +26,6 @@ classdef MISS_HIT
 
             % default options
             default_args = {['--fix ', suppress_output]};
-%             default_args = {['--fix ']};
             default_args(1:nargin) = varargin;
 
             % get active editor content


### PR DESCRIPTION
The path for mh_style in mac is not in the default path of matlab, therefore add an path setting in line 15
Remember to substitute your own username for rookie in line 15;
Because I have tried ~ for convenience but failed